### PR TITLE
Close sockets if input is read.

### DIFF
--- a/daemon.cpp
+++ b/daemon.cpp
@@ -299,6 +299,8 @@ int main(int argc, char* argv[]) {
 			error("ERROR writing to socket");
 			close(newsockfd);
 		}
+		shutdown(sockfd, SHUT_WR);
+		shutdown(newsockfd, SHUT_WR);
 	}
 
 	/**


### PR DESCRIPTION
Solves https://github.com/xkonni/raspberry-remote/issues/34

Tried (at least for our use case): No more left open (CLOSE_WAIT) socket connections are kept open (can be checked with `sudo lsof -i -P -n`) as described in https://github.com/xkonni/raspberry-remote/issues/34

Tested and worked on local setup.